### PR TITLE
Fix comments referencing arrays in FFT

### DIFF
--- a/strobe.ino
+++ b/strobe.ino
@@ -23,8 +23,8 @@ arduinoFFT FFT = arduinoFFT();
 unsigned int samplingPeriod;
 unsigned long microSeconds;
 
-double vReal[SAMPLES];  //create vector of size SAMPLES to hold real values
-double vImag[SAMPLES];  //create vector of size SAMPLES to hold imaginary values
+double vReal[SAMPLES];  //create array of size SAMPLES to hold real values
+double vImag[SAMPLES];  //create array of size SAMPLES to hold imaginary values
 
 void setup() {
   samplingPeriod = round(1000000 * (1.0 / SAMPLING_FREQUENCY));  //Period in microseconds


### PR DESCRIPTION
## Summary
- correct comments to reference arrays instead of vectors for FFT buffers

## Testing
- `arduino-cli --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432ec42840832891dd7099188879f0