### PR TITLE
Fix strobe timing types

### DIFF
--- a/strobe.ino
+++ b/strobe.ino
@@ -69,8 +69,8 @@ void strobe(double freq) {
   float adjustment = map(reading, 0, 1024, -19, 20);
 
   // Set the interval, and 'On' portion of the strobe
-  int interval = 1000000 / (freq + adjustment);
-  int pause = interval / 5;
+  unsigned long interval = 1000000 / (freq + adjustment);
+  unsigned long pause = interval / 5;
   interval -= pause;
 
   // Looping 'On' and 'Off', for one second


### PR DESCRIPTION
## Summary
- use `unsigned long` for strobe timing variables in `strobe.ino`

## Testing
- `arduino-cli compile --fqbn arduino:avr:nano vocalStrobe.ino` *(fails: platform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68432dbb40b0832899a7ee1ac3db9adc