### PR TITLE
Fix comment typo

### DIFF
--- a/strobe.ino
+++ b/strobe.ino
@@ -53,7 +53,7 @@ void loop() {
 
   /*Find peak frequency */
   double peak = FFT.MajorPeak(vReal, SAMPLES, SAMPLING_FREQUENCY);
-  // Serial.println(peak);  // Printing the percieved frequency to the serial monitor.
+  // Serial.println(peak);  // Printing the perceived frequency to the serial monitor.
 
   if (peak < 75) {
     PORTB |= _BV(5);  // digitalWrite(LED_BUILTIN, HIGH);


### PR DESCRIPTION
## Summary
- fix 'percieved' typo to 'perceived' in comment

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432d8b15a083289bc88fb0e15a79af