### PR TITLE
Fix analogRead range for potentiometer mapping

### DIFF
--- a/strobe.ino
+++ b/strobe.ino
@@ -66,7 +66,7 @@ void loop() {
 void strobe(double freq) {
 
   float reading = analogRead(A0);
-  float adjustment = map(reading, 0, 1024, -19, 20);
+  float adjustment = map(reading, 0, 1023, -19, 20);
 
   // Set the interval, and 'On' portion of the strobe
   int interval = 1000000 / (freq + adjustment);


### PR DESCRIPTION
## Summary
- correct mapping of potentiometer reading to ensure full range is used

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68432cd3118c83289a28e08de53fe23c