### PR TITLE
Refactor strobe adjustment input

### DIFF
--- a/strobe.ino
+++ b/strobe.ino
@@ -55,18 +55,19 @@ void loop() {
   double peak = FFT.MajorPeak(vReal, SAMPLES, SAMPLING_FREQUENCY);
   // Serial.println(peak);  // Printing the perceived frequency to the serial monitor.
 
+  // Read the strobe adjustment once per loop
+  float reading = analogRead(A0);
+  float adjustment = map(reading, 0, 1023, -19, 20);
+
   if (peak < 75) {
     PORTB |= _BV(5);  // digitalWrite(LED_BUILTIN, HIGH);
   } else {
     PORTB &= ~_BV(5);  // digitalWrite(LED_BUILTIN, LOW);
-    strobe(peak);
+    strobe(peak, adjustment);
   }
 }
 
-void strobe(double freq) {
-
-  float reading = analogRead(A0);
-  float adjustment = map(reading, 0, 1023, -19, 20);
+void strobe(double freq, float adjustment) {
 
   // Set the interval, and 'On' portion of the strobe
   unsigned long interval = 1000000 / (freq + adjustment);


### PR DESCRIPTION
## Summary
- read potentiometer (A0) once after computing the FFT peak
- pass the mapped adjustment value to `strobe`
- remove redundant analog read from `strobe`

## Testing
- `arduino-cli --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433351f0588328a12321ad27d6db26