### PR TITLE
Remove samplingPeriod variable

### DIFF
--- a/strobe.ino
+++ b/strobe.ino
@@ -21,7 +21,6 @@
 
 arduinoFFT FFT = arduinoFFT();
 
-unsigned int samplingPeriod;
 unsigned long microSeconds;
 
 volatile double vReal[SAMPLES];  // buffer for real values
@@ -59,7 +58,6 @@ ISR(TIMER1_COMPA_vect) {
 }
 
 void setup() {
-  samplingPeriod = 1000000UL / SAMPLING_FREQUENCY;  //Period in microseconds
   DDRD |= _BV(5);                                                // pinMode(5, OUTPUT);
   DDRB |= _BV(5);                                                // pinMode(LED_BUILTIN, OUTPUT);
   setupTimer1();


### PR DESCRIPTION
## Summary
- delete the unused `samplingPeriod` variable
- remove the assignment in `setup()`

## Testing
- `arduino --verify strobe.ino`

------
https://chatgpt.com/codex/tasks/task_e_6843399e33008328b8e98c2c5f31cfa9