### PR TITLE
Add host C++ unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(vocalStrobe)
+set(CMAKE_CXX_STANDARD 11)
+
+enable_testing()
+
+add_subdirectory(tests)

--- a/src/strobe.cpp
+++ b/src/strobe.cpp
@@ -1,0 +1,8 @@
+#include "strobe.h"
+
+std::pair<int, int> computePauseInterval(double freq, float adjustment) {
+    int interval = 1000000 / (freq + adjustment);
+    int pause = interval / 5;
+    interval -= pause;
+    return {pause, interval};
+}

--- a/src/strobe.h
+++ b/src/strobe.h
@@ -1,0 +1,8 @@
+#ifndef STROBE_H
+#define STROBE_H
+
+#include <utility>
+
+std::pair<int, int> computePauseInterval(double freq, float adjustment);
+
+#endif // STROBE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+)
+# Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+add_library(strobe STATIC ../src/strobe.cpp)
+
+target_include_directories(strobe PUBLIC ../src)
+
+add_executable(test_strobe test_strobe.cpp)
+target_link_libraries(test_strobe strobe gtest_main)
+
+add_test(NAME strobe_test COMMAND test_strobe)

--- a/tests/test_strobe.cpp
+++ b/tests/test_strobe.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+#include "strobe.h"
+
+TEST(StrobeTest, PauseIntervalNoAdjustment) {
+    auto res = computePauseInterval(100.0, 0.0f);
+    int expected_interval = 1000000 / (100.0 + 0.0);
+    int expected_pause = expected_interval / 5;
+    expected_interval -= expected_pause;
+    EXPECT_EQ(res.first, expected_pause);
+    EXPECT_EQ(res.second, expected_interval);
+}
+
+TEST(StrobeTest, PauseIntervalWithAdjustment) {
+    auto res = computePauseInterval(50.0, 10.0f);
+    int expected_interval = 1000000 / (50.0 + 10.0);
+    int expected_pause = expected_interval / 5;
+    expected_interval -= expected_pause;
+    EXPECT_EQ(res.first, expected_pause);
+    EXPECT_EQ(res.second, expected_interval);
+}
+
+TEST(StrobeTest, NegativeAdjustment) {
+    auto res = computePauseInterval(200.0, -20.0f);
+    int expected_interval = 1000000 / (200.0 - 20.0);
+    int expected_pause = expected_interval / 5;
+    expected_interval -= expected_pause;
+    EXPECT_EQ(res.first, expected_pause);
+    EXPECT_EQ(res.second, expected_interval);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add computePauseInterval helper
- add GoogleTest unit tests for strobe calculation
- build the unit tests via CMake
- fix test include path

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68432ed111b48328a827169d0ec0215a